### PR TITLE
Add env, envFromSecret to Deployment

### DIFF
--- a/charts/universal/Chart.yaml
+++ b/charts/universal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: universal
-version: 0.0.3
+version: 0.0.4
 description: A universal Helm chart for deploying services to Kubernetes
 maintainers:
 - name: rantanevich

--- a/charts/universal/ci/deployment-values.yaml
+++ b/charts/universal/ci/deployment-values.yaml
@@ -41,14 +41,12 @@ deployments:
       web:
         imagePullPolicy: IfNotPresent
         env:
-        - name: JAVA_OPTS
-          value: -Xms4g -Xmx8g
-        - name: LOGGING_LEVEL_ROOT
-          value: info
-        - name: POD_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
+          JAVA_OPTS: -Xms4g -Xmx8g
+          LOGGING_LEVEL_ROOT: info
+        envFromSecret:
+          example-auth:
+            AUTH_USERNAME: username
+            AUTH_PASSWORD: password
         startupProbe:
           httpGet:
             path: /health

--- a/charts/universal/ci/deployment-values.yaml
+++ b/charts/universal/ci/deployment-values.yaml
@@ -41,12 +41,14 @@ deployments:
       web:
         imagePullPolicy: IfNotPresent
         env:
-          JAVA_OPTS: -Xms4g -Xmx8g
-          LOGGING_LEVEL_ROOT: info
-        envFromSecret:
-          example-auth:
-            AUTH_USERNAME: username
-            AUTH_PASSWORD: password
+        - name: JAVA_OPTS
+          value: -Xms4g -Xmx8g
+        - name: LOGGING_LEVEL_ROOT
+          value: info
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         startupProbe:
           httpGet:
             path: /health

--- a/charts/universal/ci/deployment-values.yaml
+++ b/charts/universal/ci/deployment-values.yaml
@@ -41,14 +41,8 @@ deployments:
       web:
         imagePullPolicy: IfNotPresent
         env:
-        - name: JAVA_OPTS
-          value: -Xms4g -Xmx8g
-        - name: LOGGING_LEVEL_ROOT
-          value: info
-        - name: POD_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
+          JAVA_OPTS: -Xms4g -Xmx8g
+          LOGGING_LEVEL_ROOT: info
         startupProbe:
           httpGet:
             path: /health

--- a/charts/universal/templates/helpers/_container.tpl
+++ b/charts/universal/templates/helpers/_container.tpl
@@ -9,9 +9,25 @@
   {{- if has $fname (list "lifecycle" "livenessProbe" "readinessProbe" "resources" "securityContext" "startupProbe") }}
   {{ $fname }}:
     {{- toYaml $fvalue | nindent 4 }}
-  {{- else if has $fname (list "args" "command" "env" "ports" "volumeMounts") }}
+  {{- else if has $fname (list "args" "command" "ports" "volumeMounts") }}
   {{ $fname }}:
   {{- toYaml $fvalue | nindent 2 }}
+  {{- end }}
+  {{- end }}
+  {{- if or .env .envFromSecret }}
+  env:
+  {{- range $envName, $envValue := .env }}
+  - name: {{ $envName }}
+    value: {{ $envValue | quote }}
+  {{- end }}
+  {{- range $secretName, $items := .envFromSecret }}
+  {{- range $envName, $secretKey := $items }}
+  - name: {{ $envName }}
+    valueFrom:
+      secretKeyRef:
+        name: {{ $secretName }}
+        key: {{ $secretKey }}
+  {{- end }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/universal/templates/helpers/_pod.tpl
+++ b/charts/universal/templates/helpers/_pod.tpl
@@ -23,9 +23,16 @@
 {{- with (coalesce $val.serviceAccountName $.Values.global.serviceAccountName) }}
 serviceAccountName: {{ . }}
 {{- end }}
-{{- with (coalesce $val.imagePullSecrets $.Values.image.pullSecrets) }}
+{{- if kindIs "slice" $val.imagePullSecrets }}
+{{- with $val.imagePullSecrets }}
 imagePullSecrets:
 {{- toYaml . | nindent 0 }}
+{{- end }}
+{{- else if kindIs "slice" $.Values.image.pullSecrets }}
+{{- with $.Values.image.pullSecrets }}
+imagePullSecrets:
+{{- toYaml . | nindent 0 }}
+{{- end }}
 {{- end }}
 containers:
 {{- include "helpers.container" (dict "value" $val.containers "context" $) }}

--- a/charts/universal/tests/deployment_test.yaml
+++ b/charts/universal/tests/deployment_test.yaml
@@ -5,16 +5,32 @@ release:
   name: &release_name example
   namespace: &namespace sandbox
 tests:
-- it: &component web
+- it: common
   values:
-  - ../ci/deployment-values.yaml
+  - values/deployment.yaml
+  asserts:
+  - hasDocuments:
+      count: 3
+- it: &component api
+  values:
+  - values/deployment.yaml
   documentIndex: 0
   asserts:
   - containsDocument: &document
       apiVersion: apps/v1
       kind: Deployment
-      name: example-web
+      name: example-api
       namespace: *namespace
+  - equal:
+      path: spec.replicas
+      value: 1
+  - equal:
+      path: spec.strategy
+      value:
+        type: RollingUpdate
+        rollingUpdate:
+          maxSurge: 1
+          maxUnavailable: 0
   - equal:
       path: spec.replicas
       value: 1
@@ -27,9 +43,239 @@ tests:
       path: spec.template.metadata.labels
       value: *selector_labels
   - equal:
+      path: spec.template.spec.dnsConfig
+      value:
+        nameservers:
+        - 10.96.0.10
+        searches:
+        - default.svc.cluster.local
+        - svc.cluster.local
+        - cluster.local
+        options:
+        - name: ndots
+          value: "5"
+  - equal:
+      path: spec.template.spec.dnsPolicy
+      value: None
+  - equal:
       path: spec.template.spec.nodeSelector
       value:
+        disktype: ssd
         kubernetes.io/os: linux
+  - equal:
+      path: spec.template.spec.tolerations
+      value:
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+  - equal:
+      path: spec.template.spec.topologySpreadConstraints
+      value:
+      - maxSkew: 1
+        topologyKey: linux,kubernetes.io/arch
+        whenUnsatisfiable: ScheduleAnyway
+  - equal:
+      path: spec.template.spec.containers[0].name
+      value: api
+  - equal:
+      path: spec.template.spec.containers[0].image
+      value: api:1.2.3
+  - equal:
+      path: spec.template.spec.containers[0].imagePullPolicy
+      value: Always
+  - equal:
+      path: spec.template.spec.containers[0].ports
+      value:
+      - containerPort: 8080
+        protocol: TCP
+  - equal:
+      path: spec.template.spec.containers[0].startupProbe
+      value:
+        httpGet:
+          path: /ping
+          port: 8080
+        failureThreshold: 12
+        periodSeconds: 5
+  - equal:
+      path: spec.template.spec.containers[0].securityContext
+      value:
+        allowPrivilegeEscalation: false
+- it: &component worker
+  values:
+  - values/deployment.yaml
+  documentIndex: 2
+  asserts:
+  - containsDocument:
+      <<: *document
+      name: example-worker
+  - equal:
+      path: spec.replicas
+      value: 5
+  - equal:
+      path: spec.strategy
+      value:
+        type: Recreate
+  - equal:
+      path: spec.selector.matchLabels
+      value: &selector_labels
+        app.kubernetes.io/name: *release_name
+        app.kubernetes.io/component: *component
+  - equal:
+      path: spec.template.metadata.labels
+      value: *selector_labels
+  - equal:
+      path: spec.template.spec.hostNetwork
+      value: true
+  - equal:
+      path: spec.template.spec.dnsPolicy
+      value: ClusterFirstWithHostNet
+  - equal:
+      path: spec.template.spec.priorityClassName
+      value: Production
+  - equal:
+      path: spec.template.spec.terminationGracePeriodSeconds
+      value: 60
+  - equal:
+      path: spec.template.spec.affinity
+      value:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+  - equal:
+      path: spec.template.spec.volumes
+      value:
+      - name: git
+        emptyDir: {}
+  - equal:
+      path: spec.template.spec.imagePullSecrets
+      value:
+      - name: dockerhub
+  - equal:
+      path: spec.template.spec.initContainers[0].name
+      value: wait-postgres
+  - equal:
+      path: spec.template.spec.initContainers[0].image
+      value: postgres:14.5-alpine
+  - equal:
+      path: spec.template.spec.initContainers[0].command
+      value:
+      - sh
+      - -ec
+      - |
+        until (pg_isready -h example.org -p 5432 -U postgres); do
+          sleep 1
+        done
+  - equal:
+      path: spec.template.spec.initContainers[0].resources
+      value:
+        requests:
+          cpu: 50m
+          memory: 50Mi
+        limits:
+          cpu: 50m
+          memory: 50Mi
+  - equal:
+      path: spec.template.spec.containers[0].name
+      value: sql-proxy
+  - equal:
+      path: spec.template.spec.containers[0].image
+      value: gcr.io/cloudsql-docker/gce-proxy:1.30.1
+  - equal:
+      path: spec.template.spec.containers[0].command
+      value:
+      - /cloud_sql_proxy
+      - -ip_address_types=PRIVATE
+      - -instances=$(CLOUD_SQL_PROXY_CONNECTION)=tcp:$(CLOUD_SQL_PROXY_PORT)
+  - equal:
+      path: spec.template.spec.containers[0].env
+      value:
+      - name: CLOUD_SQL_PROXY_CONNECTION
+        valueFrom:
+          secretKeyRef:
+            name: example-mysql
+            key: connection_name
+      - name: CLOUD_SQL_PROXY_PORT
+        valueFrom:
+          secretKeyRef:
+            name: example-mysql
+            key: port
+  - equal:
+      path: spec.template.spec.containers[1].name
+      value: worker
+  - equal:
+      path: spec.template.spec.containers[1].image
+      value: worker:1.2.3
+  - equal:
+      path: spec.template.spec.containers[1].env
+      value:
+      - name: DB_HOST
+        value: 127.0.0.1
+      - name: DB_NAME
+        valueFrom:
+          secretKeyRef:
+            name: example-mysql
+            key: database
+      - name: DB_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: example-mysql
+            key: password
+      - name: DB_USERNAME
+        valueFrom:
+          secretKeyRef:
+            name: example-mysql
+            key: username
+  - equal:
+      path: spec.template.spec.containers[1].volumeMounts
+      value:
+      - name: git
+        mountPath: /git
+  - equal:
+      path: spec.template.spec.containers[1].livenessProbe
+      value:
+        exec:
+          command: ["cat", "/tmp/healthy"]
+        initialDelaySeconds: 15
+        periodSeconds: 10
+  - equal:
+      path: spec.template.spec.containers[1].resources
+      value:
+        limits:
+          cpu: 1000m
+          memory: 1Gi
+        requests:
+          cpu: 1000m
+          memory: 1Gi
+- it: &component ui
+  values:
+  - values/deployment.yaml
+  documentIndex: 1
+  asserts:
+  - containsDocument:
+      <<: *document
+      name: example-ui
+  - equal:
+      path: spec.replicas
+      value: 3
+  - equal:
+      path: spec.selector.matchLabels
+      value: &selector_labels
+        app.kubernetes.io/name: *release_name
+        app.kubernetes.io/component: *component
+  - equal:
+      path: spec.template.metadata.labels
+      value: *selector_labels
+  - equal:
+      path: spec.template.spec.hostname
+      value: ui
+  - equal:
+      path: spec.template.spec.priority
+      value: 0
   - equal:
       path: spec.template.spec.affinity
       value:
@@ -45,131 +291,45 @@ tests:
                   - S2
               topologyKey: topology.kubernetes.io/zone
   - equal:
-      path: spec.template.spec.tolerations
+      path: spec.template.spec.securityContext
       value:
-      - key: node.kubernetes.io/unreachable
-        operator: Exists
-        effect: NoExecute
-  - equal:
-      path: spec.template.spec.volumes
-      value:
-      - name: kubexit
-        emptyDir: {}
-      - name: guard
-        emptyDir:
-          medium: Memory
-  - equal:
-      path: spec.template.spec.initContainers[0].name
-      value: kubexit
-  - equal:
-      path: spec.template.spec.initContainers[0].image
-      value: karlkfi/kubexit:0.3.2
-  - equal:
-      path: spec.template.spec.initContainers[0].imagePullPolicy
-      value: Always
-  - equal:
-      path: spec.template.spec.initContainers[0].command
-      value: ["cp", "/bin/kubexit", "/kubexit/kubexit"]
-  - equal:
-      path: spec.template.spec.initContainers[0].volumeMounts
-      value:
-      - name: kubexit
-        mountPath: /kubexit
+        runAsUser: 1000
+        runAsGroup: 3000
+        fsGroup: 2000
   - equal:
       path: spec.template.spec.containers[0].name
-      value: web
+      value: ui
   - equal:
       path: spec.template.spec.containers[0].image
-      value: traefik/whoami:v1.8.7
+      value: ui:1.2.3
   - equal:
-      path: spec.template.spec.containers[0].imagePullPolicy
-      value: IfNotPresent
+      path: spec.template.spec.containers[0].command
+      value: ["printenv"]
   - equal:
-      path: spec.template.spec.containers[0].env
+      path: spec.template.spec.containers[0].args
       value:
-      - name: JAVA_OPTS
-        value: -Xms4g -Xmx8g
-      - name: LOGGING_LEVEL_ROOT
-        value: info
-      - name: POD_IP
-        valueFrom:
-          fieldRef:
-            fieldPath: status.podIP
+      - HOSTNAME
+      - KUBERNETES_PORT
   - equal:
-      path: spec.template.spec.containers[0].startupProbe
+      path: spec.template.spec.containers[0].lifecycle
+      value:
+        preStop:
+          exec:
+            command: ["/usr/sbin/nginx", "-s", "quit"]
+  - equal:
+      path: spec.template.spec.containers[0].readinessProbe
       value:
         httpGet:
-          path: /health
-          port: 80
-        failureThreshold: 30
-        periodSeconds: 10
-- it: &component worker
-  values:
-  - ../ci/deployment-values.yaml
-  documentIndex: 1
-  asserts:
-  - containsDocument:
-      <<: *document
-      name: example-worker
-  - equal:
-      path: spec.replicas
-      value: 3
-  - equal:
-      path: spec.selector.matchLabels
-      value: &selector_labels
-        app.kubernetes.io/name: *release_name
-        app.kubernetes.io/component: *component
-  - equal:
-      path: spec.template.metadata.labels
-      value: *selector_labels
-  - equal:
-      path: spec.template.spec.affinity
-      value:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: kubernetes.io/os
-                operator: In
-                values:
-                - linux
-  - equal:
-      path: spec.template.spec.hostname
-      value: worker
-  - equal:
-      path: spec.template.spec.topologySpreadConstraints
-      value:
-      - topologyKey: linux,kubernetes.io/arch
-        whenUnsatisfiable: ScheduleAnyway
-        maxSkew: 1
-  - equal:
-      path: spec.template.spec.automountServiceAccountToken
-      value: false
-  - equal:
-      path: spec.template.spec.containers[0].name
-      value: worker
-  - equal:
-      path: spec.template.spec.containers[0].name
-      value: worker
-  - equal:
-      path: spec.template.spec.containers[0].image
-      value: traefik/whoami:v1.8.7
-  - equal:
-      path: spec.template.spec.containers[0].imagePullPolicy
-      value: Always
-  - equal:
-      path: spec.template.spec.containers[0].livenessProbe
-      value:
-        exec:
-          command: ["cat", "/tmp/healthy"]
-        initialDelaySeconds: 15
-        periodSeconds: 10
+          path: /ping
+          port: 3000
+        initialDelaySeconds: 60
+        periodSeconds: 15
+        failureThreshold: 3
+        successThreshold: 1
+        timeoutSeconds: 5
   - equal:
       path: spec.template.spec.containers[0].resources
       value:
-        limits:
+        requests:
           cpu: 100m
           memory: 128Mi
-        requests:
-          cpu: 50m
-          memory: 64Mi

--- a/charts/universal/tests/global_test.yaml
+++ b/charts/universal/tests/global_test.yaml
@@ -1,0 +1,131 @@
+suite: test global
+templates:
+- deployment.yaml
+release:
+  name: &release_name example
+  namespace: &namespace sandbox
+tests:
+- it: common
+  values:
+  - values/global.yaml
+  asserts:
+  - hasDocuments:
+      count: 2
+- it: imagePullSecrets | global ([]), deploy (null), expect (null)
+  set:
+    image:
+      pullSecrets: []
+    deployments:
+      web: {}
+  asserts:
+  - isNull:
+      path: spec.template.spec.imagePullSecrets
+- it: imagePullSecrets | global ([]), deploy ([]), expect (null)
+  set:
+    image:
+      pullSecrets: []
+    deployments:
+      web:
+        imagePullSecrets: []
+  asserts:
+  - isNull:
+      path: spec.template.spec.imagePullSecrets
+- it: imagePullSecrets | global ([dockerhub]), deploy ([]), expect (null)
+  set:
+    image:
+      pullSecrets:
+      - name: dockerhub
+    deployments:
+      web:
+        imagePullSecrets: []
+  asserts:
+  - isNull:
+      path: spec.template.spec.imagePullSecrets
+- it: imagePullSecrets | global ([]), deploy ([dockerhub]), expect ([dockerhub])
+  set:
+    image:
+      pullSecrets: []
+    deployments:
+      web:
+        imagePullSecrets:
+        - name: dockerhub
+  asserts:
+  - equal:
+      path: spec.template.spec.imagePullSecrets
+      value:
+      - name: dockerhub
+- it: imagePullSecrets | global ([vmware]), deploy ([dockerhub]), expect ([dockerhub])
+  set:
+    image:
+      pullSecrets:
+      - name: vmware
+    deployments:
+      web:
+        imagePullSecrets:
+        - name: dockerhub
+  asserts:
+  - equal:
+      path: spec.template.spec.imagePullSecrets
+      value:
+      - name: dockerhub
+- it: imagePullSecrets | global ([dockerhub]), deploy (null), expect ([dockerhub])
+  set:
+    image:
+      pullSecrets:
+      - name: dockerhub
+    deployments:
+      web: {}
+  asserts:
+  - equal:
+      path: spec.template.spec.imagePullSecrets
+      value:
+      - name: dockerhub
+- it: &component api
+  values:
+  - values/global.yaml
+  documentIndex: 0
+  asserts:
+  - equal:
+      path: spec.revisionHistoryLimit
+      value: 5
+  - equal:
+      path: spec.template.spec.automountServiceAccountToken
+      value: false
+  - equal:
+      path: spec.template.spec.enableServiceLinks
+      value: false
+  - equal:
+      path: spec.template.spec.serviceAccountName
+      value: whoami
+  - isNull:
+      path: spec.template.spec.imagePullSecrets
+  - equal:
+      path: spec.template.spec.containers[0].image
+      value: whoami:v1.8.7
+- it: &component worker
+  values:
+  - values/global.yaml
+  documentIndex: 1
+  asserts:
+  - equal:
+      path: spec.revisionHistoryLimit
+      value: 10
+  - equal:
+      path: spec.template.spec.automountServiceAccountToken
+      value: true
+  - equal:
+      path: spec.template.spec.enableServiceLinks
+      value: true
+  - equal:
+      path: spec.template.spec.serviceAccountName
+      value: worker
+  - equal:
+      path: spec.template.spec.imagePullSecrets
+      value:
+      - name: dockerhub
+  - equal:
+      path: spec.template.spec.containers[0].image
+      value: alpine:latest
+  - equal:
+      path: spec.template.spec.containers[0].imagePullPolicy
+      value: Always

--- a/charts/universal/tests/values/deployment.yaml
+++ b/charts/universal/tests/values/deployment.yaml
@@ -1,0 +1,160 @@
+deployments:
+  api:
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 0
+    dnsPolicy: None
+    dnsConfig:
+      nameservers:
+      - 10.96.0.10
+      searches:
+      - default.svc.cluster.local
+      - svc.cluster.local
+      - cluster.local
+      options:
+      - name: ndots
+        value: "5"
+    nodeSelector:
+      kubernetes.io/os: linux
+      disktype: ssd
+    tolerations:
+    - key: node.kubernetes.io/unreachable
+      operator: Exists
+      effect: NoExecute
+    topologySpreadConstraints:
+    - topologyKey: linux,kubernetes.io/arch
+      whenUnsatisfiable: ScheduleAnyway
+      maxSkew: 1
+    containers:
+      api:
+        image: api:1.2.3
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+        startupProbe:
+          httpGet:
+            path: /ping
+            port: 8080
+          failureThreshold: 12
+          periodSeconds: 5
+        securityContext:
+          allowPrivilegeEscalation: false
+  worker:
+    replicas: 5
+    strategy:
+      type: Recreate
+    hostNetwork: true
+    dnsPolicy: ClusterFirstWithHostNet
+    priorityClassName: Production
+    terminationGracePeriodSeconds: 60
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: kubernetes.io/os
+              operator: In
+              values:
+              - linux
+    volumes:
+    - name: git
+      emptyDir: {}
+    imagePullSecrets:
+    - name: dockerhub
+    initContainers:
+      wait-postgres:
+        image: postgres:14.5-alpine
+        command:
+        - sh
+        - -ec
+        - |
+          until (pg_isready -h example.org -p 5432 -U postgres); do
+            sleep 1
+          done
+        resources:
+          requests:
+            cpu: 50m
+            memory: 50Mi
+          limits:
+            cpu: 50m
+            memory: 50Mi
+    containers:
+      sql-proxy:
+        image: gcr.io/cloudsql-docker/gce-proxy:1.30.1
+        command:
+        - /cloud_sql_proxy
+        - -ip_address_types=PRIVATE
+        - -instances=$(CLOUD_SQL_PROXY_CONNECTION)=tcp:$(CLOUD_SQL_PROXY_PORT)
+        envFromSecret:
+          example-mysql:
+            CLOUD_SQL_PROXY_CONNECTION: connection_name
+            CLOUD_SQL_PROXY_PORT: port
+      worker:
+        image: worker:1.2.3
+        env:
+          DB_HOST: 127.0.0.1
+        envFromSecret:
+          example-mysql:
+            DB_NAME: database
+            DB_USERNAME: username
+            DB_PASSWORD: password
+        volumeMounts:
+        - name: git
+          mountPath: /git
+        livenessProbe:
+          exec:
+            command: ["cat", "/tmp/healthy"]
+          initialDelaySeconds: 15
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 1Gi
+          requests:
+            cpu: 1000m
+            memory: 1Gi
+  ui:
+    replicas: 3
+    hostname: ui
+    priority: 0
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+              - key: security
+                operator: In
+                values:
+                - S2
+            topologyKey: topology.kubernetes.io/zone
+    securityContext:
+      runAsUser: 1000
+      runAsGroup: 3000
+      fsGroup: 2000
+    containers:
+      ui:
+        image: ui:1.2.3
+        command: ["printenv"]
+        args: ["HOSTNAME", "KUBERNETES_PORT"]
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/usr/sbin/nginx", "-s", "quit"]
+        readinessProbe:
+          httpGet:
+            path: /ping
+            port: 3000
+          initialDelaySeconds: 60
+          periodSeconds: 15
+          failureThreshold: 3
+          successThreshold: 1
+          timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi

--- a/charts/universal/tests/values/global.yaml
+++ b/charts/universal/tests/values/global.yaml
@@ -1,0 +1,26 @@
+global:
+  revisionHistoryLimit: 10
+  automountServiceAccountToken: true
+  enableServiceLinks: false
+  serviceAccountName: whoami
+
+image:
+  repository: alpine
+  tag: latest
+  pullSecrets:
+  - name: dockerhub
+
+deployments:
+  api:
+    revisionHistoryLimit: 5
+    automountServiceAccountToken: false
+    imagePullSecrets: []
+    containers:
+      api:
+        image: whoami:v1.8.7
+  worker:
+    serviceAccountName: worker
+    enableServiceLinks: true
+    containers:
+      worker:
+        imagePullPolicy: Always


### PR DESCRIPTION
The changes allow to specify `env` in more compact way. And add opportunity to specify `env` from Secret.

```yaml
deployments:
  web:
    containers:
      whoami:
        env:
          DB_HOST: 127.0.0.1
        envFromSecret:
          whoami-mysql:
            DB_NAME: database
            DB_USER: username
            DB_PASSWORD: password
```